### PR TITLE
opt(io): optimize `ParallelStateProvider`

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -55,7 +55,7 @@ use std::{
     time::Instant,
 };
 use tokio::sync::{
-    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    mpsc::{UnboundedReceiver, UnboundedSender},
     oneshot::{self, error::TryRecvError},
 };
 use tracing::*;

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -15,8 +15,8 @@ use reth_provider::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut, StaticFileWriter},
     writer::UnifiedStorageWriter,
     BlockReader, DBProvider, HeaderProvider, LatestStateProviderRef, OriginalValuesKnown,
-    ProviderError, StateChangeWriter, StateProvider, StateProviderOptions, StateWriter,
-    StaticFileProviderFactory, StatsReader, TransactionVariant, STATE_PROVIDER_OPTS,
+    ProviderError, StateChangeWriter, StateProvider, StateWriter, StaticFileProviderFactory,
+    StatsReader, TransactionVariant, STATE_PROVIDER_OPTS,
 };
 use reth_prune_types::PruneModes;
 use reth_revm::database::StateProviderDatabase;
@@ -27,7 +27,6 @@ use reth_stages_api::{
 };
 use std::{
     cmp::Ordering,
-    num::NonZero,
     ops::RangeInclusive,
     sync::Arc,
     task::{ready, Context, Poll},

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -57,6 +57,7 @@ notify = { workspace = true, default-features = false, features = ["macos_fseven
 parking_lot.workspace = true
 dashmap = { workspace = true, features = ["inline"] }
 strum.workspace = true
+paste.workspace = true
 
 # test-utils
 once_cell = { workspace = true, optional = true }

--- a/crates/storage/provider/src/providers/state/macros.rs
+++ b/crates/storage/provider/src/providers/state/macros.rs
@@ -5,7 +5,6 @@
 ///
 /// Used to implement provider traits.
 
-use std::sync::Arc;
 
 macro_rules! delegate_impls_to_as_ref {
     (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $(fn $func:ident$(<$($generic_arg:ident: $generic_arg_ty:path),*>)?(&self, $($arg:ident: $argty:ty),*) -> $ret:path;)* })* ) => {


### PR DESCRIPTION
If there are no concurrent requests, process the requests in place to eliminate synchronization overhead.

Benchmark for block 17034870 to 17134870 using grevm 1.0:
- LatestStateProvider (no parallel): 403.92 Mgas/second
- ParallelStateProvider before opt. (parallel = 8): 331.64 Mgas/second
- ParallelStateProvider after opt. (parallel = 8): 544.19 Mgas/second